### PR TITLE
pass ISelectionContext to VoxelShape getters

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 mc_version=1.16.5
 forge_version=36.1.0
-mod_version=3.0.0
+mod_version=3.0.1
 
 scala_version=2.13.4
 scala_compat_version=2.13:0.9.1

--- a/src/main/scala/codechicken/microblock/EdgeMicroblock.scala
+++ b/src/main/scala/codechicken/microblock/EdgeMicroblock.scala
@@ -14,7 +14,7 @@ import codechicken.multipart.api.part.{TEdgePart, TMultiPart, TNormalOcclusionPa
 import codechicken.multipart.block.TileMultiPart
 import codechicken.multipart.util.PartRayTraceResult
 import net.minecraft.client.renderer.RenderType
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 
 object EdgePlacement extends PlacementProperties {
 
@@ -196,7 +196,7 @@ trait PostMicroblock extends Microblock with TPartialOcclusionPart with TNormalO
 
     override def getBounds = PostMicroFactory.aBounds(shape)
 
-    override def getOutlineShape = PostMicroFactory.aShapes(shape)
+    override def getShape(context: ISelectionContext) = PostMicroFactory.aShapes(shape)
 
     override def getOcclusionShape = PostMicroFactory.aShapes(shape)
 

--- a/src/main/scala/codechicken/microblock/HollowMicroblock.scala
+++ b/src/main/scala/codechicken/microblock/HollowMicroblock.scala
@@ -11,7 +11,7 @@ import codechicken.multipart.api.part.{TFacePart, TNormalOcclusionPart}
 import codechicken.multipart.util.PartRayTraceResult
 import com.mojang.blaze3d.matrix.MatrixStack
 import net.minecraft.client.renderer.{ActiveRenderInfo, IRenderTypeBuffer, RenderType}
-import net.minecraft.util.math.shapes.{VoxelShape, VoxelShapes}
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape, VoxelShapes}
 import org.lwjgl.opengl.GL11
 
 import scala.jdk.CollectionConverters._
@@ -158,7 +158,7 @@ trait HollowMicroblock extends CommonMicroblock with TFacePart with TNormalOcclu
 
     override def getBounds: Cuboid6 = FaceMicroFactory.aBounds(shape)
 
-    override def getOutlineShape: VoxelShape = getCollisionShape
+    override def getShape(context: ISelectionContext): VoxelShape = getCollisionShape(context)
 
     override def getPartialOcclusionShape = HollowMicroFactory.pShape(shape)
 
@@ -223,9 +223,9 @@ trait HollowMicroblock extends CommonMicroblock with TFacePart with TNormalOcclu
             .map(c => c.apply(tr))
     }
 
-    override def getCollisionShape = getCollisionBoxes.map(VoxelShapeCache.getShape).reduce(VoxelShapes.or)
+    override def getCollisionShape(context: ISelectionContext) = getCollisionBoxes.map(VoxelShapeCache.getShape).reduce(VoxelShapes.or)
 
-    override def getInteractionShape = new SubHitVoxelShape(getCollisionShape, getCollisionBoxes.map(c => new IndexedCuboid6(0, c)).asJava)
+    override def getInteractionShape = new SubHitVoxelShape(getCollisionShape(ISelectionContext.empty()), getCollisionBoxes.map(c => new IndexedCuboid6(0, c)).asJava)
 
     override def allowCompleteOcclusion = true
 

--- a/src/main/scala/codechicken/microblock/Microblock.scala
+++ b/src/main/scala/codechicken/microblock/Microblock.scala
@@ -12,6 +12,7 @@ import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.CompoundNBT
+import net.minecraft.util.math.shapes.ISelectionContext
 import net.minecraft.world.Explosion
 import net.minecraftforge.api.distmarker.{Dist, OnlyIn}
 import net.minecraftforge.client.model.ModelLoader
@@ -160,9 +161,9 @@ trait CommonMicroblock extends Microblock with TPartialOcclusionPart with TMicro
 
     def getSlotMask = 1 << getSlot
 
-    override def getOutlineShape = VoxelShapeCache.getShape(getBounds)
+    override def getShape(context: ISelectionContext) = VoxelShapeCache.getShape(getBounds)
 
-    override def getPartialOcclusionShape = getOutlineShape
+    override def getPartialOcclusionShape = getShape(ISelectionContext.empty())
 
     override def itemFactoryID = microFactory.getFactoryID
 }

--- a/src/main/scala/codechicken/multipart/api/part/TMultiPart.scala
+++ b/src/main/scala/codechicken/multipart/api/part/TMultiPart.scala
@@ -19,7 +19,7 @@ import net.minecraft.item.{ItemStack, ItemUseContext}
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.tileentity.TileEntityType
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.shapes.{VoxelShape, VoxelShapes}
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape, VoxelShapes}
 import net.minecraft.util.{ActionResultType, Hand}
 import net.minecraft.world.Explosion
 import net.minecraft.world.chunk.Chunk
@@ -110,14 +110,17 @@ abstract class TMultiPart {
      */
     def occlusionTest(npart: TMultiPart): Boolean = true
 
-    def getOutlineShape: VoxelShape = VoxelShapes.empty()
+    def getShape(context:ISelectionContext): VoxelShape = VoxelShapes.empty()
 
-    //TODO pass through ISelectionContext
-    def getCollisionShape: VoxelShape = getOutlineShape
+    def getCollisionShape(context: ISelectionContext): VoxelShape = getShape(context)
 
-    def getRenderOcclusionShape: VoxelShape = getOutlineShape
+    def getRenderOcclusionShape: VoxelShape = getShape(ISelectionContext.empty)
 
-    def getInteractionShape: VoxelShape = getOutlineShape
+    def getInteractionShape: VoxelShape = getShape(ISelectionContext.empty)
+
+    def getBlockSupportShape: VoxelShape = getCollisionShape(ISelectionContext.empty)
+
+    def getVisualShape(context: ISelectionContext): VoxelShape = getCollisionShape(context)
 
     /**
      * Harvest this part, removing it from the container tile and dropping items if necessary.

--- a/src/main/scala/codechicken/multipart/block/BlockMultiPart.java
+++ b/src/main/scala/codechicken/multipart/block/BlockMultiPart.java
@@ -74,13 +74,13 @@ public class BlockMultiPart extends Block {
     @Override
     public VoxelShape getShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context) {
         TileMultiPart tile = getTile(world, pos);
-        return tile == null ? VoxelShapes.empty() : tile.getOutlineShape();
+        return tile == null ? VoxelShapes.empty() : tile.getShape(context);
     }
 
     @Override
     public VoxelShape getCollisionShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context) {
         TileMultiPart tile = getTile(world, pos);
-        return tile == null ? VoxelShapes.empty() : tile.getCollisionShape();
+        return tile == null ? VoxelShapes.empty() : tile.getCollisionShape(context);
     }
 
     @Override
@@ -94,9 +94,18 @@ public class BlockMultiPart extends Block {
         TileMultiPart tile = getTile(world, pos);
         return tile == null ? VoxelShapes.empty() : tile.getInteractionShape();
     }
-    
-    //TODO getBlockSupportShape
-    //TODO getVisualShape
+
+    @Override
+    public VoxelShape getBlockSupportShape(BlockState state, IBlockReader world, BlockPos pos) {
+        TileMultiPart tile = getTile(world, pos);
+        return tile == null ? VoxelShapes.empty() : tile.getBlockSupportShape();
+    }
+
+    @Override
+    public VoxelShape getVisualShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context) {
+        TileMultiPart tile = getTile(world, pos);
+        return tile == null ? VoxelShapes.empty() : tile.getVisualShape(context);
+    }
 
     @Override
     public float getExplosionResistance(BlockState state, IBlockReader world, BlockPos pos, Explosion explosion) {

--- a/src/main/scala/codechicken/multipart/client/ClientEventHandler.java
+++ b/src/main/scala/codechicken/multipart/client/ClientEventHandler.java
@@ -10,6 +10,7 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraftforge.client.event.DrawHighlightEvent;
 import net.minecraftforge.common.MinecraftForge;
 
@@ -39,7 +40,7 @@ public class ClientEventHandler {
         if (!part.drawHighlight(hit, info, mStack, buffers, partialTicks)) {
             Matrix4 mat = new Matrix4(mStack);
             mat.translate(hit.getBlockPos());
-            RenderUtils.bufferShapeHitBox(mat, buffers, info, part.getOutlineShape());
+            RenderUtils.bufferShapeHitBox(mat, buffers, info, part.getShape(ISelectionContext.empty()));
         }
         event.setCanceled(true);
     }

--- a/src/main/scala/codechicken/multipart/minecraft/ButtonPart.java
+++ b/src/main/scala/codechicken/multipart/minecraft/ButtonPart.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.*;
+import net.minecraft.util.math.shapes.ISelectionContext;
 
 
 public class ButtonPart extends McSidedStatePart implements IFaceRedstonePart {
@@ -103,7 +104,7 @@ public class ButtonPart extends McSidedStatePart implements IFaceRedstonePart {
     }
 
     private void updateState() {
-        boolean arrows = sensitive() && !world().getEntitiesOfClass(ArrowEntity.class, getOutlineShape().bounds().move(pos())).isEmpty();
+        boolean arrows = sensitive() && !world().getEntitiesOfClass(ArrowEntity.class, getShape(ISelectionContext.empty()).bounds().move(pos())).isEmpty();
         boolean pressed = pressed();
 
         if (arrows != pressed) {

--- a/src/main/scala/codechicken/multipart/minecraft/McStatePart.java
+++ b/src/main/scala/codechicken/multipart/minecraft/McStatePart.java
@@ -21,6 +21,7 @@ import net.minecraft.item.ItemUseContext;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -107,13 +108,13 @@ public abstract class McStatePart extends TMultiPart implements TNormalOcclusion
     }
 
     @Override
-    public VoxelShape getOutlineShape() {
-        return state.getShape(world(), pos());
+    public VoxelShape getShape(ISelectionContext context) {
+        return state.getShape(world(), pos(), context);
     }
 
     @Override
-    public VoxelShape getCollisionShape() {
-        return state.getCollisionShape(world(), pos());
+    public VoxelShape getCollisionShape(ISelectionContext context) {
+        return state.getCollisionShape(world(), pos(), context);
     }
 
     @Override
@@ -129,6 +130,16 @@ public abstract class McStatePart extends TMultiPart implements TNormalOcclusion
     @Override
     public VoxelShape getOcclusionShape() {
         return state.getCollisionShape(null, null);
+    }
+
+    @Override
+    public VoxelShape getBlockSupportShape() {
+        return state.getBlockSupportShape(world(), pos());
+    }
+
+    @Override
+    public VoxelShape getVisualShape(ISelectionContext context) {
+        return state.getVisualShape(world(), pos(), context);
     }
 
     @Override
@@ -149,7 +160,7 @@ public abstract class McStatePart extends TMultiPart implements TNormalOcclusion
 
     @Override
     public Cuboid6 getBounds() {
-        return new Cuboid6(getOutlineShape().bounds());
+        return new Cuboid6(getShape(ISelectionContext.empty()).bounds());
     }
 
     @Override

--- a/src/main/scala/codechicken/multipart/util/MergedVoxelShapeHolder.java
+++ b/src/main/scala/codechicken/multipart/util/MergedVoxelShapeHolder.java
@@ -1,0 +1,49 @@
+package codechicken.multipart.util;
+
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Created by covers1624 on 3/10/20.
+ */
+public class MergedVoxelShapeHolder<T> {
+
+    private final Set<VoxelShape> shapeParts = new HashSet<>();
+    private final Set<VoxelShape> partCache = new HashSet<>();
+
+    private VoxelShape mergedShape;
+    private Function<VoxelShape, VoxelShape> postProcess;
+
+    public MergedVoxelShapeHolder<T> setPostProcessHook(Function<VoxelShape, VoxelShape> postProcess) {
+        this.postProcess = postProcess;
+        return this;
+    }
+
+    public void clear() {
+        shapeParts.clear();
+        partCache.clear();
+        mergedShape = null;
+    }
+
+    public VoxelShape update(Collection<T> things, Function<T, VoxelShape> extractor) {
+        partCache.clear();
+        for (T thing : things) {
+            partCache.add(extractor.apply(thing));
+        }
+        if (!partCache.equals(shapeParts) || mergedShape == null) {
+            shapeParts.clear();
+            shapeParts.addAll(partCache);
+            //Same as VoxelShapes.or(VoxelShapes.empty(), shapeParts.toArray()); Except we skip useless array creation.
+            VoxelShape merged = shapeParts.stream().reduce(VoxelShapes.empty(), VoxelShapes::or);
+            mergedShape = postProcess.apply(merged);
+        }
+
+        return mergedShape;
+    }
+
+}

--- a/src/main/scala/codechicken/multipart/util/MultipartVoxelShape.java
+++ b/src/main/scala/codechicken/multipart/util/MultipartVoxelShape.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.doubles.DoubleList;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.math.shapes.VoxelShape;
 
@@ -37,7 +38,7 @@ public class MultipartVoxelShape extends VoxelShape {
                 .map(part -> {
                     BlockRayTraceResult hit = part.getInteractionShape().clip(start, end, pos);
                     if (hit == null) {
-                        hit = part.getOutlineShape().clip(start, end, pos);
+                        hit = part.getShape(ISelectionContext.empty()).clip(start, end, pos);
                     }
                     if (hit == null) {
                         return null;


### PR DESCRIPTION
MergedVoxelShapeHolder now accepts an extractor function as needed instead of having one cached. I only saw TileMultipart use this class, but if its used elsewhere and pre-setting the extractor is required, I can un-deprecate the setters and original non-extractor aware function.