### PR TITLE
Fix build failing on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ task mixinAnnotations(type: Exec) {
         tasks.compileScala.outputs.files.asFileTree.each {
             def name = it.toString()
             if (name.endsWith(".class") && name.contains("mixin")) {
-                args << destPath.relativize(it.toPath()).toString().replace(".class", "").replace(File.pathSeparator, ".").replace("/", ".")
+                args << destPath.relativize(it.toPath()).toString().replace(".class", "").replace(File.pathSeparator, ".").replace(File.separator, ".")
             }
         }
         setArgs(args)


### PR DESCRIPTION
The build script currently fails on Windows machines with the error `javac: invalid flag: codechicken\multipart\internal\mixin\TileEntityMixin`. This is because Gradle uses Windows directory separators (`\`) when running on Windows, and they aren't being turned into periods by the `mixinAnnotations` task. Using `File.separator` will correctly replace backslashes on Windows and forward slashes on non-Windows machines.

Tested on Windows 10 and Ubuntu 20.04