### PR TITLE
Add synchronized blocks around HashSets used in MergedVoxelShapeHolder

### DIFF
--- a/src/main/scala/codechicken/multipart/util/MergedVoxelShapeHolder.java
+++ b/src/main/scala/codechicken/multipart/util/MergedVoxelShapeHolder.java
@@ -38,14 +38,11 @@ public class MergedVoxelShapeHolder<T> {
             }
 
             if (!partCache.equals(shapeParts) || mergedShape == null) {
-                VoxelShape merged;
-
                 shapeParts.clear();
                 shapeParts.addAll(partCache);
 
                 //Same as VoxelShapes.or(VoxelShapes.empty(), shapeParts.toArray()); Except we skip useless array creation.
-                merged = shapeParts.stream().reduce(VoxelShapes.empty(), VoxelShapes::or);
-
+                VoxelShape merged = shapeParts.stream().reduce(VoxelShapes.empty(), VoxelShapes::or);
                 mergedShape = postProcess.apply(merged);
             }
         }

--- a/src/main/scala/codechicken/multipart/util/MergedVoxelShapeHolder.java
+++ b/src/main/scala/codechicken/multipart/util/MergedVoxelShapeHolder.java
@@ -40,13 +40,11 @@ public class MergedVoxelShapeHolder<T> {
             if (!partCache.equals(shapeParts) || mergedShape == null) {
                 VoxelShape merged;
 
-                synchronized (shapeParts) {
-                    shapeParts.clear();
-                    shapeParts.addAll(partCache);
+                shapeParts.clear();
+                shapeParts.addAll(partCache);
 
-                    //Same as VoxelShapes.or(VoxelShapes.empty(), shapeParts.toArray()); Except we skip useless array creation.
-                    merged = shapeParts.stream().reduce(VoxelShapes.empty(), VoxelShapes::or);
-                }
+                //Same as VoxelShapes.or(VoxelShapes.empty(), shapeParts.toArray()); Except we skip useless array creation.
+                merged = shapeParts.stream().reduce(VoxelShapes.empty(), VoxelShapes::or);
 
                 mergedShape = postProcess.apply(merged);
             }


### PR DESCRIPTION
Prevents ConcurrentModificationExceptions when a multipart tile is raytraced by a separate thread from the render thread (such as is the case when DynamicSurroundings is doing sound processing). Fixes #89.

I've been running my own world with this PR in-place for over 10 minutes now while staring at a Cover, and it normally would have crashed within a minute beforehand. I don't see any more ConcurrentModificationExceptions being logged by DynamicSurrounding's thread either.