### PR TITLE
Add a check to prevent sendDescUpdate from being called on the client

### DIFF
--- a/src/main/scala/codechicken/multipart/util/MultiPartLoadHandler.java
+++ b/src/main/scala/codechicken/multipart/util/MultiPartLoadHandler.java
@@ -71,6 +71,10 @@ public class MultiPartLoadHandler {
 
         @Override
         public void tick() {
+            if (level == null || level.isClientSide) {
+                return;
+            }
+
             if (!failed && !loaded) {
                 if (tag != null) {
                     TileMultiPart newTile = TileMultiPart.fromNBT(tag);


### PR DESCRIPTION
This avoids crashes in rare cases where a `MultiPartLoadHandler.TileNBTContainer` gets added to a client-side world, such as when setting a multipart down after picking it up using the "Carry On" mod.

Fixes #87 