### PR TITLE
Array out of bound check to resolve compatibility issue with MineColonies

### DIFF
--- a/src/main/scala/codechicken/microblock/ItemMicroBlock.scala
+++ b/src/main/scala/codechicken/microblock/ItemMicroBlock.scala
@@ -103,7 +103,6 @@ object ItemMicroBlock {
         stack.getOrCreateTag()
         if (!stack.getTag.contains("factory_id")) {
             //Wut..
-            logger.error("Found stack with no factory_id tag? {}", stack)
             -2000
         } else {
             stack.getTag.getInt("factory_id")

--- a/src/main/scala/codechicken/microblock/ItemMicroBlock.scala
+++ b/src/main/scala/codechicken/microblock/ItemMicroBlock.scala
@@ -110,7 +110,13 @@ object ItemMicroBlock {
         }
     }
 
-    def getFactory(stack: ItemStack) = CommonMicroFactory.factories(getFactoryID(stack))
+    def getFactory(stack: ItemStack): CommonMicroFactory =  {
+        val factoryId = getFactoryID(stack)
+        if (factoryId < 0 || factoryId > CommonMicroFactory.factories.length) {
+            return null
+        }
+        CommonMicroFactory.factories(factoryId)
+    }
 
     def getSize(stack: ItemStack): Int = {
         stack.getOrCreateTag()


### PR DESCRIPTION
Resolves #95 
To show request-able items in the post box:

- Minecolonies takes all registered items from forge registries
- creates brand new item stacks form them 
-  then sorts them by calling getName. 
- get name for microblocks is overridden and calls getFactory() 
- which in turn calls getFactoryId

It breaks because those brand new item stacks do not have the factory_id tag for microblocks. And getFactoryId returns hard coded -2000 value.
We should be checking array bounds  before trying to fetch a factory.