### PR TITLE
Micromaterial dynamic rendering, Add missing torches/levers

### DIFF
--- a/src/main/java/codechicken/microblock/api/MicroMaterialClient.java
+++ b/src/main/java/codechicken/microblock/api/MicroMaterialClient.java
@@ -5,8 +5,11 @@ import codechicken.lib.vec.Vector3;
 import codechicken.microblock.part.MicroblockPart;
 import codechicken.microblock.util.MaskedCuboid;
 import codechicken.multipart.util.PartRayTraceResult;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.world.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,6 +26,8 @@ public abstract class MicroMaterialClient {
     public abstract RenderType getItemRenderLayer();
 
     public abstract boolean renderCuboids(CCRenderState ccrs, @Nullable RenderType layer, Iterable<MaskedCuboid> cuboids);
+
+    public void renderDynamic(MicroblockPart part, @Nullable ItemTransforms.TransformType transformType, PoseStack pStack, MultiBufferSource buffers, int packedLight, int packedOverlay, float partialTicks) { }
 
     public void addHitEffects(MicroblockPart part, PartRayTraceResult hit, ParticleEngine engine) { }
 

--- a/src/main/java/codechicken/microblock/client/MicroBlockPartRenderer.java
+++ b/src/main/java/codechicken/microblock/client/MicroBlockPartRenderer.java
@@ -1,10 +1,11 @@
 package codechicken.microblock.client;
 
 import codechicken.lib.render.CCRenderState;
-import codechicken.microblock.api.BlockMicroMaterial;
 import codechicken.microblock.api.MicroMaterialClient;
 import codechicken.microblock.part.MicroblockPart;
 import codechicken.multipart.api.part.render.PartRenderer;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,5 +23,13 @@ public class MicroBlockPartRenderer implements PartRenderer<MicroblockPart> {
             return clientMaterial.renderCuboids(ccrs, layer, part.getRenderCuboids(false));
         }
         return false;
+    }
+
+    @Override
+    public void renderDynamic(MicroblockPart part, PoseStack pStack, MultiBufferSource buffers, int packedLight, int packedOverlay, float partialTicks) {
+        MicroMaterialClient clientMaterial = MicroMaterialClient.get(part.material);
+        if (clientMaterial != null) {
+            clientMaterial.renderDynamic(part, null, pStack, buffers, packedLight, packedOverlay, partialTicks);
+        }
     }
 }

--- a/src/main/java/codechicken/microblock/client/MicroblockItemRenderer.java
+++ b/src/main/java/codechicken/microblock/client/MicroblockItemRenderer.java
@@ -3,9 +3,7 @@ package codechicken.microblock.client;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.item.IItemRenderer;
 import codechicken.lib.util.TransformUtils;
-import codechicken.lib.vec.Matrix4;
 import codechicken.lib.vec.Vector3;
-import codechicken.microblock.api.BlockMicroMaterial;
 import codechicken.microblock.api.MicroMaterial;
 import codechicken.microblock.api.MicroMaterialClient;
 import codechicken.microblock.part.StandardMicroFactory;
@@ -37,8 +35,9 @@ public class MicroblockItemRenderer implements IItemRenderer {
         MicroblockPart part = factory.create(true, material);
         part.setShape(size, factory.getItemSlot());
 
-        Matrix4 mat = new Matrix4(mStack);
-        mat.translate(Vector3.CENTER.copy().subtract(part.getBounds().center()));
+        mStack.pushPose();
+        Vector3 offset = Vector3.CENTER.copy().subtract(part.getBounds().center());
+        mStack.translate(offset.x, offset.y, offset.z);
 
         CCRenderState ccrs = CCRenderState.instance();
         ccrs.reset();
@@ -46,8 +45,11 @@ public class MicroblockItemRenderer implements IItemRenderer {
         ccrs.overlay = packedOverlay;
 
         RenderType layer = clientMaterial.getItemRenderLayer();
-        ccrs.bind(layer, buffers, mat);
+        ccrs.bind(layer, buffers, mStack);
         clientMaterial.renderCuboids(ccrs, null, part.getRenderCuboids(true));
+
+        clientMaterial.renderDynamic(part, transformType, mStack, buffers, packedLight, packedOverlay, 0);
+        mStack.popPose();
     }
 
     @Override

--- a/src/main/java/codechicken/microblock/client/MicroblockRender.java
+++ b/src/main/java/codechicken/microblock/client/MicroblockRender.java
@@ -65,7 +65,7 @@ public class MicroblockRender {
     private static final CrashLock LOCK = new CrashLock("Already Initialized");
     private static final ThreadLocal<PipelineState> PIPELINES = ThreadLocal.withInitial(PipelineState::create);
 
-    private static final RenderType HIGHLIGHT_RENDER_TYPE = RenderType.create(MOD_ID + ":highlight", DefaultVertexFormat.BLOCK, VertexFormat.Mode.QUADS, 255, RenderType.CompositeState.builder()
+    public static final RenderType HIGHLIGHT_RENDER_TYPE = RenderType.create(MOD_ID + ":highlight", DefaultVertexFormat.BLOCK, VertexFormat.Mode.QUADS, 255, RenderType.CompositeState.builder()
             .setShaderState(RenderType.BLOCK_SHADER)
             .setTextureState(RenderType.BLOCK_SHEET)
             .setWriteMaskState(RenderType.COLOR_DEPTH_WRITE)

--- a/src/main/java/codechicken/multipart/minecraft/ButtonPart.java
+++ b/src/main/java/codechicken/multipart/minecraft/ButtonPart.java
@@ -153,6 +153,13 @@ public class ButtonPart extends McSidedStatePart implements FaceRedstonePart {
         public StoneButtonPart(BlockState state) { super(ModContent.stoneButtonPartType, (ButtonBlock) Blocks.STONE_BUTTON, state); }
     }
 
+    public static class PolishedBlackstoneButtonPart extends ButtonPart {
+
+        public PolishedBlackstoneButtonPart() { super(ModContent.polishedBlackstoneButtonPartType, (ButtonBlock) Blocks.POLISHED_BLACKSTONE_BUTTON); }
+
+        public PolishedBlackstoneButtonPart(BlockState state) { super(ModContent.polishedBlackstoneButtonPartType, (ButtonBlock) Blocks.POLISHED_BLACKSTONE_BUTTON, state); }
+    }
+
     public static class OakButtonPart extends ButtonPart {
 
         public OakButtonPart() { super(ModContent.oakButtonPartType, (ButtonBlock) Blocks.OAK_BUTTON); }
@@ -193,6 +200,20 @@ public class ButtonPart extends McSidedStatePart implements FaceRedstonePart {
         public DarkOakButtonPart() { super(ModContent.darkOakButtonPartType, (ButtonBlock) Blocks.DARK_OAK_BUTTON); }
 
         public DarkOakButtonPart(BlockState state) { super(ModContent.darkOakButtonPartType, (ButtonBlock) Blocks.DARK_OAK_BUTTON, state); }
+    }
+
+    public static class CrimsonButtonPart extends ButtonPart {
+
+        public CrimsonButtonPart() { super(ModContent.crimsonButtonPartType, (ButtonBlock) Blocks.CRIMSON_BUTTON); }
+
+        public CrimsonButtonPart(BlockState state) { super(ModContent.crimsonButtonPartType, (ButtonBlock) Blocks.CRIMSON_BUTTON, state); }
+    }
+
+    public static class WarpedButtonPart extends ButtonPart {
+
+        public WarpedButtonPart() { super(ModContent.warpedButtonPartType, (ButtonBlock) Blocks.WARPED_BUTTON); }
+
+        public WarpedButtonPart(BlockState state) { super(ModContent.warpedButtonPartType, (ButtonBlock) Blocks.WARPED_BUTTON, state); }
     }
 
 }

--- a/src/main/java/codechicken/multipart/minecraft/ClientInit.java
+++ b/src/main/java/codechicken/multipart/minecraft/ClientInit.java
@@ -16,14 +16,18 @@ public class ClientInit {
 
     private static void onClientSetup(FMLClientSetupEvent event) {
         MultipartClientRegistry.register(ModContent.torchPartType, PartBakedModelRenderer.simple());
+        MultipartClientRegistry.register(ModContent.soulTorchPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.redstoneTorchPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.leverPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.stoneButtonPartType, PartBakedModelRenderer.simple());
+        MultipartClientRegistry.register(ModContent.polishedBlackstoneButtonPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.oakButtonPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.spruceButtonPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.birchButtonPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.jungleButtonPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.acaciaButtonPartType, PartBakedModelRenderer.simple());
         MultipartClientRegistry.register(ModContent.darkOakButtonPartType, PartBakedModelRenderer.simple());
+        MultipartClientRegistry.register(ModContent.crimsonButtonPartType, PartBakedModelRenderer.simple());
+        MultipartClientRegistry.register(ModContent.warpedButtonPartType, PartBakedModelRenderer.simple());
     }
 }

--- a/src/main/java/codechicken/multipart/minecraft/McStatePart.java
+++ b/src/main/java/codechicken/multipart/minecraft/McStatePart.java
@@ -129,7 +129,8 @@ public abstract class McStatePart extends BaseMultipart implements NormalOcclusi
 
     @Override
     public VoxelShape getOcclusionShape() {
-        return state.getCollisionShape(null, null);
+        VoxelShape cShape = state.getCollisionShape(null, null);
+        return cShape.isEmpty() ? state.getShape(null, null) : cShape;
     }
 
     @Override

--- a/src/main/java/codechicken/multipart/minecraft/ModContent.java
+++ b/src/main/java/codechicken/multipart/minecraft/ModContent.java
@@ -35,6 +35,9 @@ public class ModContent {
     @ObjectHolder ("torch")
     public static MultipartType<TorchPart> torchPartType;
 
+    @ObjectHolder ("soul_torch")
+    public static MultipartType<SoulTorchPart> soulTorchPartType;
+
     @ObjectHolder ("redstone_torch")
     public static MultipartType<RedstoneTorchPart> redstoneTorchPartType;
 
@@ -44,6 +47,8 @@ public class ModContent {
     @ObjectHolder ("stone_button")
     public static MultipartType<ButtonPart.StoneButtonPart> stoneButtonPartType;
 
+    @ObjectHolder ("polished_blackstone_button")
+    public static MultipartType<ButtonPart.PolishedBlackstoneButtonPart> polishedBlackstoneButtonPartType;
     @ObjectHolder ("oak_button")
     public static MultipartType<ButtonPart.OakButtonPart> oakButtonPartType;
     @ObjectHolder ("spruce_button")
@@ -56,6 +61,10 @@ public class ModContent {
     public static MultipartType<ButtonPart.AcaciaButtonPart> acaciaButtonPartType;
     @ObjectHolder ("dark_oak_button")
     public static MultipartType<ButtonPart.DarkOakButtonPart> darkOakButtonPartType;
+    @ObjectHolder ("crimson_button")
+    public static MultipartType<ButtonPart.CrimsonButtonPart> crimsonButtonPartType;
+    @ObjectHolder ("warped_button")
+    public static MultipartType<ButtonPart.WarpedButtonPart> warpedButtonPartType;
 
     @SubscribeEvent
     public static void onRegisterMultiParts(RegistryEvent.Register<MultipartType<?>> event) {
@@ -64,17 +73,21 @@ public class ModContent {
         ModLoadingContext.get().setActiveContainer(null);
 
         r.register(new SimpleMultipartType<>(e -> new TorchPart()).setRegistryName("torch"));
+        r.register(new SimpleMultipartType<>(e -> new SoulTorchPart()).setRegistryName("soul_torch"));
         r.register(new SimpleMultipartType<>(e -> new RedstoneTorchPart()).setRegistryName("redstone_torch"));
         r.register(new SimpleMultipartType<>(e -> new LeverPart()).setRegistryName("lever"));
 
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.StoneButtonPart()).setRegistryName("stone_button"));
 
+        r.register(new SimpleMultipartType<>(e -> new ButtonPart.PolishedBlackstoneButtonPart()).setRegistryName("polished_blackstone_button"));
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.OakButtonPart()).setRegistryName("oak_button"));
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.SpruceButtonPart()).setRegistryName("spruce_button"));
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.BirchButtonPart()).setRegistryName("birch_button"));
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.JungleButtonPart()).setRegistryName("jungle_button"));
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.AcaciaButtonPart()).setRegistryName("acacia_button"));
         r.register(new SimpleMultipartType<>(e -> new ButtonPart.DarkOakButtonPart()).setRegistryName("dark_oak_button"));
+        r.register(new SimpleMultipartType<>(e -> new ButtonPart.CrimsonButtonPart()).setRegistryName("crimson_button"));
+        r.register(new SimpleMultipartType<>(e -> new ButtonPart.WarpedButtonPart()).setRegistryName("warped_button"));
 
         ModLoadingContext.get().setActiveContainer(container);
     }
@@ -87,17 +100,21 @@ public class ModContent {
         ModLoadingContext.get().setActiveContainer(null);
 
         r.register(new Converter<>(TorchPart::new, TorchPart::new, Items.TORCH, Blocks.TORCH, Blocks.WALL_TORCH).setRegistryName("torch"));
+        r.register(new Converter<>(SoulTorchPart::new, SoulTorchPart::new, Items.SOUL_TORCH, Blocks.SOUL_TORCH, Blocks.SOUL_WALL_TORCH).setRegistryName("soul_torch"));
         r.register(new Converter<>(RedstoneTorchPart::new, RedstoneTorchPart::new, Items.REDSTONE_TORCH, Blocks.REDSTONE_TORCH, Blocks.REDSTONE_WALL_TORCH).setRegistryName("redstone_torch"));
         r.register(new Converter<>(LeverPart::new, LeverPart::new, Items.LEVER, Blocks.LEVER).setRegistryName("lever"));
 
         r.register(new Converter<>(ButtonPart.StoneButtonPart::new, ButtonPart.StoneButtonPart::new, Items.STONE_BUTTON, Blocks.STONE_BUTTON).setRegistryName("stone_button"));
 
+        r.register(new Converter<>(ButtonPart.PolishedBlackstoneButtonPart::new, ButtonPart.PolishedBlackstoneButtonPart::new, Items.POLISHED_BLACKSTONE_BUTTON, Blocks.POLISHED_BLACKSTONE_BUTTON).setRegistryName("polished_blackstone_button"));
         r.register(new Converter<>(ButtonPart.OakButtonPart::new, ButtonPart.OakButtonPart::new, Items.OAK_BUTTON, Blocks.OAK_BUTTON).setRegistryName("oak_button"));
         r.register(new Converter<>(ButtonPart.SpruceButtonPart::new, ButtonPart.SpruceButtonPart::new, Items.SPRUCE_BUTTON, Blocks.SPRUCE_BUTTON).setRegistryName("spruce_button"));
         r.register(new Converter<>(ButtonPart.BirchButtonPart::new, ButtonPart.BirchButtonPart::new, Items.BIRCH_BUTTON, Blocks.BIRCH_BUTTON).setRegistryName("birch_button"));
         r.register(new Converter<>(ButtonPart.JungleButtonPart::new, ButtonPart.JungleButtonPart::new, Items.JUNGLE_BUTTON, Blocks.JUNGLE_BUTTON).setRegistryName("jungle_button"));
         r.register(new Converter<>(ButtonPart.AcaciaButtonPart::new, ButtonPart.AcaciaButtonPart::new, Items.ACACIA_BUTTON, Blocks.ACACIA_BUTTON).setRegistryName("acacia_button"));
         r.register(new Converter<>(ButtonPart.DarkOakButtonPart::new, ButtonPart.DarkOakButtonPart::new, Items.DARK_OAK_BUTTON, Blocks.DARK_OAK_BUTTON).setRegistryName("dark_oak_button"));
+        r.register(new Converter<>(ButtonPart.CrimsonButtonPart::new, ButtonPart.CrimsonButtonPart::new, Items.CRIMSON_BUTTON, Blocks.CRIMSON_BUTTON).setRegistryName("crimson_button"));
+        r.register(new Converter<>(ButtonPart.WarpedButtonPart::new, ButtonPart.WarpedButtonPart::new, Items.WARPED_BUTTON, Blocks.WARPED_BUTTON).setRegistryName("warped_button"));
 
         ModLoadingContext.get().setActiveContainer(container);
     }

--- a/src/main/java/codechicken/multipart/minecraft/SoulTorchPart.java
+++ b/src/main/java/codechicken/multipart/minecraft/SoulTorchPart.java
@@ -1,0 +1,31 @@
+package codechicken.multipart.minecraft;
+
+import codechicken.multipart.api.MultipartType;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class SoulTorchPart extends TorchPart {
+
+    public SoulTorchPart() {
+    }
+
+    public SoulTorchPart(BlockState state) {
+        super(state);
+    }
+
+    @Override
+    protected Block getStandingBlock() {
+        return Blocks.SOUL_TORCH;
+    }
+
+    @Override
+    protected Block getWallBlock() {
+        return Blocks.SOUL_WALL_TORCH;
+    }
+
+    @Override
+    public MultipartType<?> getType() {
+        return ModContent.soulTorchPartType;
+    }
+}


### PR DESCRIPTION
* Add a renderDynamic callback on MicroMaterials, called from both part renderer and item renderer
* McStateParts use a block's collision shape for occlusion. The BlockState's regular shape is now queried in cases where collision shape is empty (such as for levers and buttons)
* Added missing button styles and Soul Torch to Minecraft parts for consistency