### PR TITLE
Bug fixes

### DIFF
--- a/src/main/java/codechicken/multipart/api/PartConverter.java
+++ b/src/main/java/codechicken/multipart/api/PartConverter.java
@@ -1,7 +1,9 @@
 package codechicken.multipart.api;
 
+import codechicken.multipart.CBMultipart;
 import codechicken.multipart.api.part.MultiPart;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.LevelAccessor;
@@ -16,6 +18,11 @@ import java.util.Collections;
  * Created by covers1624 on 4/17/20.
  */
 public abstract class PartConverter extends ForgeRegistryEntry<PartConverter> {
+
+    /**
+     * The Forge registry name used by PartConverter.
+     */
+    public static final ResourceLocation PART_CONVERTERS = new ResourceLocation(CBMultipart.MOD_ID, "part_converters");
 
     private static final ConversionResult<Collection<MultiPart>> EMPTY_LIST = new ConversionResult<>(Collections.emptyList(), false);
     private static final ConversionResult<MultiPart> EMPTY = new ConversionResult<>(null, false);

--- a/src/main/java/codechicken/multipart/block/TileMultipart.java
+++ b/src/main/java/codechicken/multipart/block/TileMultipart.java
@@ -52,6 +52,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static net.minecraft.world.level.block.Block.*;
+
 /**
  * The host tile, capable of containing {@link MultiPart} instances.
  */
@@ -295,6 +297,7 @@ public class TileMultipart extends BlockEntity implements IChunkLoadTile {
         if (!isRemoved()) {
             TileMultipart tile = partRemoved(this);
             tile.notifyPartChange(part);
+            tile.notifyShapeChange();
             tile.setChanged();
             tile.markRender();
             return tile;
@@ -510,6 +513,17 @@ public class TileMultipart extends BlockEntity implements IChunkLoadTile {
     }
 
     /**
+     * Notifies neighboring blocks that a shape has changed
+     */
+    public void notifyShapeChange() {
+        if (level != null) {
+            BlockState state = level.getBlockState(getBlockPos());
+            state.updateNeighbourShapes(level, getBlockPos(), UPDATE_ALL | UPDATE_KNOWN_SHAPE, UPDATE_LIMIT);
+            state.updateIndirectNeighbourShapes(level, getBlockPos(), UPDATE_ALL | UPDATE_KNOWN_SHAPE, UPDATE_LIMIT);
+        }
+    }
+
+    /**
      * Called by parts when they have changed in some form that affects the world.
      * Notifies neighbor blocks, the world and parts that share this host and recalculates lighting
      */
@@ -656,6 +670,7 @@ public class TileMultipart extends BlockEntity implements IChunkLoadTile {
 
         tile.loadParts(parts);
         tile.notifyTileChange();
+        tile.notifyShapeChange();
         tile.markRender();
     }
 
@@ -695,6 +710,7 @@ public class TileMultipart extends BlockEntity implements IChunkLoadTile {
             MultipartHelper.silentAddTile(tile.level, tile.getBlockPos(), newTile);
             newTile.from(tile);
             newTile.notifyTileChange();
+            newTile.notifyShapeChange();
         }
         return newTile;
     }

--- a/src/main/java/codechicken/multipart/init/MultiPartRegistries.java
+++ b/src/main/java/codechicken/multipart/init/MultiPartRegistries.java
@@ -2,7 +2,6 @@ package codechicken.multipart.init;
 
 import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
-import codechicken.multipart.CBMultipart;
 import codechicken.multipart.api.MultipartType;
 import codechicken.multipart.api.PartConverter;
 import codechicken.multipart.api.PartConverter.ConversionResult;
@@ -51,7 +50,7 @@ public class MultiPartRegistries {
                 .setType(unsafeCast(MultipartType.class))
                 .disableSaving(), e -> MULTIPART_TYPES = (ForgeRegistry<MultipartType<?>>) e);
         event.create(new RegistryBuilder<PartConverter>()
-                        .setName(new ResourceLocation(CBMultipart.MOD_ID, "part_converters"))
+                        .setName(PartConverter.PART_CONVERTERS)
                         .setType(PartConverter.class)
                         .disableOverrides()
                         .disableSaving()

--- a/src/main/java/codechicken/multipart/minecraft/McStatePart.java
+++ b/src/main/java/codechicken/multipart/minecraft/McStatePart.java
@@ -93,8 +93,12 @@ public abstract class McStatePart extends BaseMultipart implements NormalOcclusi
 
     @Nullable
     public MultiPart setStateOnPlacement(BlockPlaceContext context) {
-        state = defaultBlockState().getBlock().getStateForPlacement(context);
-        return this;
+        BlockState state = defaultBlockState().getBlock().getStateForPlacement(context);
+        if (state != null) {
+            this.state = state;
+            return this;
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/codechicken/multipart/util/MultipartGenerator.java
+++ b/src/main/java/codechicken/multipart/util/MultipartGenerator.java
@@ -172,11 +172,11 @@ public class MultipartGenerator extends SidedGenerator<TileMultipart, MultipartG
         }
 
         {
-            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "bindPart", "(Lcodechicken/multipart/api/part/TMultipart;)V", null, null);
+            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "bindPart", "(Lcodechicken/multipart/api/part/MultiPart;)V", null, null);
             mv.visitCode();
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, 1);
-            mv.visitMethodInsn(INVOKESPECIAL, "codechicken/multipart/block/TileMultipart", "bindPart", "(Lcodechicken/multipart/api/part/TMultipart;)V", false);
+            mv.visitMethodInsn(INVOKESPECIAL, "codechicken/multipart/block/TileMultipart", "bindPart", "(Lcodechicken/multipart/api/part/MultiPart;)V", false);
             mv.visitVarInsn(ALOAD, 1);
             mv.visitTypeInsn(INSTANCEOF, iName);
             Label l2 = new Label();
@@ -192,12 +192,12 @@ public class MultipartGenerator extends SidedGenerator<TileMultipart, MultipartG
         }
 
         {
-            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "partRemoved", "(Lcodechicken/multipart/api/part/TMultipart;I)V", null, null);
+            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "partRemoved", "(Lcodechicken/multipart/api/part/MultiPart;I)V", null, null);
             mv.visitCode();
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, 1);
             mv.visitVarInsn(ILOAD, 2);
-            mv.visitMethodInsn(INVOKESPECIAL, "codechicken/multipart/block/TileMultipart", "partRemoved", "(Lcodechicken/multipart/api/part/TMultipart;I)V", false);
+            mv.visitMethodInsn(INVOKESPECIAL, "codechicken/multipart/block/TileMultipart", "partRemoved", "(Lcodechicken/multipart/api/part/MultiPart;I)V", false);
             mv.visitVarInsn(ALOAD, 1);
             mv.visitVarInsn(ALOAD, 0);
             mv.visitFieldInsn(GETFIELD, tName, vName, iDesc);
@@ -212,7 +212,7 @@ public class MultipartGenerator extends SidedGenerator<TileMultipart, MultipartG
             mv.visitEnd();
         }
         {
-            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "canAddPart", "(Lcodechicken/multipart/api/part/TMultipart;)Z", null, null);
+            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "canAddPart", "(Lcodechicken/multipart/api/part/MultiPart;)Z", null, null);
             mv.visitCode();
             mv.visitVarInsn(ALOAD, 0);
             mv.visitFieldInsn(GETFIELD, tName, vName, iDesc);
@@ -226,7 +226,7 @@ public class MultipartGenerator extends SidedGenerator<TileMultipart, MultipartG
             mv.visitLabel(l1);
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, 1);
-            mv.visitMethodInsn(INVOKESPECIAL, "codechicken/multipart/block/TileMultipart", "canAddPart", "(Lcodechicken/multipart/api/part/TMultipart;)Z", false);
+            mv.visitMethodInsn(INVOKESPECIAL, "codechicken/multipart/block/TileMultipart", "canAddPart", "(Lcodechicken/multipart/api/part/MultiPart;)Z", false);
             mv.visitInsn(IRETURN);
             mv.visitMaxs(-1, -1);
             mv.visitEnd();

--- a/src/main/java/codechicken/multipart/util/MultipartHelper.java
+++ b/src/main/java/codechicken/multipart/util/MultipartHelper.java
@@ -77,6 +77,7 @@ public class MultipartHelper {
             silentAddTile(tile.getLevel(), tile.getBlockPos(), newTile);
             newTile.from(tile);
             newTile.notifyTileChange();
+            newTile.notifyShapeChange();
         }
         return newTile;
     }

--- a/src/main/java/codechicken/multipart/util/MultipartLoadHandler.java
+++ b/src/main/java/codechicken/multipart/util/MultipartLoadHandler.java
@@ -110,6 +110,7 @@ public class MultipartLoadHandler {
                         newTile.clearRemoved();
                         level.setBlockEntity(newTile);
                         newTile.notifyTileChange();
+                        newTile.notifyShapeChange();
                         MultiPartSPH.sendDescUpdate(newTile);
                     } else {
                         level.removeBlock(getBlockPos(), false);


### PR DESCRIPTION
* Fix incorrect signature in MultipartGenerator causing invalid classes to be generated for Passthrough traits
* Upon part add/remove, call Vanilla's `onNeighborShapeChange` method on the multipart block's state. This will do a survivability check on neighboring parts, which was previously all handled by neighbor change events. This call has been added next to all `notifyTileChange()` calls during part add/remove
* Fix crash during Occlusion test if a part is converted for placement onto a surface that it cannot survive on. MCStatePart was incorrectly returning non-null even when it got a null as the placement state from the block
* Add PartConverter registry Resource Location as a static field for external mod registration