### PR TITLE
Add same block conversion support

### DIFF
--- a/src/main/java/codechicken/multipart/api/ItemMultipart.java
+++ b/src/main/java/codechicken/multipart/api/ItemMultipart.java
@@ -60,7 +60,7 @@ public abstract class ItemMultipart extends Item {
         return true;
     }
 
-    private static double getHitDepth(Vector3 vHit, int side) {
+    public static double getHitDepth(Vector3 vHit, int side) {
         return vHit.scalarProject(Rotation.axes[side]) + (side % 2 ^ 1);
     }
 

--- a/src/main/java/codechicken/multipart/handler/PlacementConversionHandler.java
+++ b/src/main/java/codechicken/multipart/handler/PlacementConversionHandler.java
@@ -1,15 +1,18 @@
 package codechicken.multipart.handler;
 
-import codechicken.lib.packet.PacketCustom;
 import codechicken.lib.raytracer.RayTracer;
+import codechicken.lib.vec.Vector3;
+import codechicken.multipart.api.ItemMultipart;
 import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.block.TileMultipart;
 import codechicken.multipart.init.MultiPartRegistries;
 import codechicken.multipart.util.MultipartHelper;
+import codechicken.multipart.util.OffsetUseOnContext;
 import net.covers1624.quack.util.CrashLock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
@@ -22,17 +25,12 @@ import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 
-import static codechicken.multipart.network.MultiPartNetwork.NET_CHANNEL;
-import static codechicken.multipart.network.MultiPartNetwork.S_MULTIPART_PLACEMENT;
-
 /**
  * Created by covers1624 on 1/9/20.
  */
 public class PlacementConversionHandler {
 
     private static final CrashLock LOCK = new CrashLock("Already initialized.");
-    //Interaction lock
-    private static final ThreadLocal<Object> placing = new ThreadLocal<>();
 
     public static void init() {
         LOCK.lock();
@@ -41,20 +39,14 @@ public class PlacementConversionHandler {
 
     private static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
         Level world = event.getWorld();
-        if (world.isClientSide) {
-            if (placing.get() != null) {
-                return;
-            }
-            placing.set(event);
-            if (place(event.getPlayer(), event.getHand(), world)) {
-                event.setCanceled(true);
-            }
-            placing.set(null);
+
+        if (place(event.getPlayer(), event.getHand())) {
+            event.setCanceled(true);
+            event.setCancellationResult(InteractionResult.sidedSuccess(world.isClientSide));
         }
     }
 
-    //TODO, unify with ItemMultiPart
-    public static boolean place(Player player, InteractionHand hand, Level world) {
+    private static boolean place(Player player, InteractionHand hand) {
         ItemStack held = player.getItemInHand(hand);
         if (held.isEmpty()) {
             return false;
@@ -63,15 +55,30 @@ public class PlacementConversionHandler {
         if (hit.getType() == HitResult.Type.MISS) {
             return false;
         }
-
-        BlockPos pos = hit.getBlockPos().relative(hit.getDirection());
+        double hitDepth = ItemMultipart.getHitDepth(
+                new Vector3(hit.getLocation()).subtract(hit.getBlockPos()),
+                hit.getDirection().ordinal()
+        );
         UseOnContext ctx = new UseOnContext(player, hand, hit);
-        MultiPart part = MultiPartRegistries.convertItem(ctx);
-        TileMultipart tile = MultipartHelper.getOrConvertTile(world, pos);
 
-        if (part == null || tile == null || !tile.canAddPart(part)) {
-            return false;
+        if (hitDepth < 1 && place(player, hand, ctx)) {
+            return true;
         }
+
+        return place(player, hand, new OffsetUseOnContext(ctx));
+    }
+
+    private static boolean place(Player player, InteractionHand hand, UseOnContext ctx) {
+        Level world = ctx.getLevel();
+        BlockPos pos = ctx.getClickedPos();
+
+        MultiPart part = MultiPartRegistries.convertItem(ctx);
+        if (part == null) return false;
+
+        TileMultipart tile = MultipartHelper.getOrConvertTile(world, pos);
+        if (tile == null) return false;
+
+        if (!tile.canAddPart(part)) return false;
 
         if (!world.isClientSide) {
             TileMultipart.addPart(world, pos, part);
@@ -80,6 +87,7 @@ public class PlacementConversionHandler {
                 world.playSound(null, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, sound.getPlaceSound(), SoundSource.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
             }
             if (!player.getAbilities().instabuild) {
+                ItemStack held = ctx.getItemInHand();
                 held.shrink(1);
                 if (held.isEmpty()) {
                     ForgeEventFactory.onPlayerDestroyItem(player, held, hand);
@@ -87,9 +95,6 @@ public class PlacementConversionHandler {
             }
         } else {
             player.swing(hand);
-            PacketCustom packet = new PacketCustom(NET_CHANNEL, S_MULTIPART_PLACEMENT);
-            packet.writeBoolean(hand == InteractionHand.MAIN_HAND);
-            packet.sendToServer();
         }
 
         return true;

--- a/src/main/java/codechicken/multipart/minecraft/TorchPart.java
+++ b/src/main/java/codechicken/multipart/minecraft/TorchPart.java
@@ -15,6 +15,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.WallTorchBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
@@ -82,19 +83,20 @@ public class TorchPart extends McSidedStatePart implements AnimateTickPart {
     @Nullable
     @Override
     public MultiPart setStateOnPlacement(BlockPlaceContext context) {
-        BlockState wallState = getWallBlock().getStateForPlacement(context);
 
         Level world = context.getLevel();
         BlockPos pos = context.getClickedPos();
+        Direction face = context.getClickedFace();
 
-        for (Direction dir : context.getNearestLookingDirections()) {
-            if (dir != Direction.UP) {
-                BlockState state = dir == Direction.DOWN ? getStandingBlock().getStateForPlacement(context) : wallState;
-                if (state != null && state.canSurvive(world, pos)) {
-                    this.state = state;
-                    return this;
-                }
-            }
+        if (face == Direction.DOWN) return null;
+
+        BlockState state = face == Direction.UP ?
+                getStandingBlock().defaultBlockState() :
+                getWallBlock().defaultBlockState().setValue(WallTorchBlock.FACING, face);
+
+        if (state.canSurvive(world, pos)) {
+            this.state = state;
+            return this;
         }
 
         return null;

--- a/src/main/java/codechicken/multipart/network/MultiPartNetwork.java
+++ b/src/main/java/codechicken/multipart/network/MultiPartNetwork.java
@@ -23,7 +23,6 @@ public class MultiPartNetwork {
 
     //Server handled.
     public static final int S_CONTROL_KEY_MODIFIER = 1;
-    public static final int S_MULTIPART_PLACEMENT = 10;
 
     public static EventNetworkChannel netChannel;
 

--- a/src/main/java/codechicken/multipart/network/MultiPartSPH.java
+++ b/src/main/java/codechicken/multipart/network/MultiPartSPH.java
@@ -7,14 +7,12 @@ import codechicken.lib.packet.PacketCustom;
 import codechicken.lib.util.LazyValuePair;
 import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.block.TileMultipart;
-import codechicken.multipart.handler.PlacementConversionHandler;
 import codechicken.multipart.init.MultiPartRegistries;
 import codechicken.multipart.util.ControlKeyModifier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.apache.commons.lang3.tuple.Pair;
@@ -36,7 +34,6 @@ public class MultiPartSPH implements ICustomPacketHandler.IServerPacketHandler {
     public void handlePacket(PacketCustom packet, ServerPlayer sender, ServerGamePacketListenerImpl handler) {
         switch (packet.getType()) {
             case S_CONTROL_KEY_MODIFIER -> ControlKeyModifier.setIsControlDown(sender, packet.readBoolean());
-            case S_MULTIPART_PLACEMENT -> PlacementConversionHandler.place(sender, packet.readBoolean() ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, sender.level);
         }
     }
 


### PR DESCRIPTION
* Conversion placement is now attempted first inside the clicked-in block before being offset and attempted again (similar to typical ItemMultipart rules)
* Replaced vanilla torch placement rules with more sane Multipart-like placement rules. For Multipart torch placements, it will only try to be placed on the clicked face itself instead of weird auto-rotation thing Vanilla does
* Removed client to server packet for executing conversion placement by simply allowing both sides to respond to the `RightClickBlock` directly