### PR TITLE
fix incorrect redstone connection masks

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 mc_version=1.18.2
 forge_version=40.0.19
-mod_version=3.1.0
+mod_version=3.1.1
 
 ccl_version=4.1.4.+
 ccl_version_max=5.0.0

--- a/src/main/java/codechicken/microblock/init/CBMicroblockModContent.java
+++ b/src/main/java/codechicken/microblock/init/CBMicroblockModContent.java
@@ -6,6 +6,7 @@ import codechicken.microblock.api.BlockMicroMaterial;
 import codechicken.microblock.api.MicroMaterial;
 import codechicken.microblock.item.ItemMicroBlock;
 import codechicken.microblock.item.SawItem;
+import codechicken.microblock.part.MicroblockPartFactory;
 import codechicken.microblock.part.corner.CornerMicroFactory;
 import codechicken.microblock.part.edge.EdgeMicroFactory;
 import codechicken.microblock.part.edge.PostMicroblockFactory;
@@ -23,6 +24,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.SimpleRecipeSerializer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -47,7 +49,7 @@ public class CBMicroblockModContent {
     private static final DeferredRegister<MultipartType<?>> MULTIPART_TYPES = DeferredRegister.create(new ResourceLocation(CBMultipart.MOD_ID, "multipart_types"), CBMicroblock.MOD_ID);
     private static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(Registry.RECIPE_SERIALIZER_REGISTRY, CBMicroblock.MOD_ID);
 
-    public static final SimpleCreativeTab MICRO_TAB = new SimpleCreativeTab("cb_microblock", () -> new ItemStack(Blocks.STONE)) {
+    public static final SimpleCreativeTab MICRO_TAB = new SimpleCreativeTab("cb_microblock", () -> ItemMicroBlock.create(1, 2, MicroMaterialRegistry.getMaterial(BlockMicroMaterial.makeMaterialKey(Blocks.GRASS_BLOCK.defaultBlockState())))) {
         @Override
         public boolean hasSearchBar() {
             return true;
@@ -104,6 +106,7 @@ public class CBMicroblockModContent {
     }
 
     private static void onRegisterMicroMaterials(RegistryEvent.Register<MicroMaterial> event) {
+        // Note: Intentionally kept in same order as Blocks class
         IForgeRegistry<MicroMaterial> r = event.getRegistry();
         r.register(new BlockMicroMaterial(Blocks.STONE));
         r.register(new BlockMicroMaterial(Blocks.GRANITE));
@@ -127,20 +130,24 @@ public class CBMicroblockModContent {
         r.register(new BlockMicroMaterial(Blocks.RED_SAND)); //TODO Gravity?
         r.register(new BlockMicroMaterial(Blocks.GRAVEL));
         r.register(new BlockMicroMaterial(Blocks.GOLD_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_GOLD_ORE));
         r.register(new BlockMicroMaterial(Blocks.IRON_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_IRON_ORE));
         r.register(new BlockMicroMaterial(Blocks.COAL_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_COAL_ORE));
+        r.register(new BlockMicroMaterial(Blocks.NETHER_GOLD_ORE));
         r.register(new BlockMicroMaterial(Blocks.OAK_LOG));
         r.register(new BlockMicroMaterial(Blocks.SPRUCE_LOG));
         r.register(new BlockMicroMaterial(Blocks.BIRCH_LOG));
         r.register(new BlockMicroMaterial(Blocks.JUNGLE_LOG));
         r.register(new BlockMicroMaterial(Blocks.ACACIA_LOG));
         r.register(new BlockMicroMaterial(Blocks.DARK_OAK_LOG));
-        r.register(new BlockMicroMaterial(Blocks.STRIPPED_OAK_LOG));
         r.register(new BlockMicroMaterial(Blocks.STRIPPED_SPRUCE_LOG));
         r.register(new BlockMicroMaterial(Blocks.STRIPPED_BIRCH_LOG));
         r.register(new BlockMicroMaterial(Blocks.STRIPPED_JUNGLE_LOG));
         r.register(new BlockMicroMaterial(Blocks.STRIPPED_ACACIA_LOG));
         r.register(new BlockMicroMaterial(Blocks.STRIPPED_DARK_OAK_LOG));
+        r.register(new BlockMicroMaterial(Blocks.STRIPPED_OAK_LOG));
         r.register(new BlockMicroMaterial(Blocks.OAK_WOOD));
         r.register(new BlockMicroMaterial(Blocks.SPRUCE_WOOD));
         r.register(new BlockMicroMaterial(Blocks.BIRCH_WOOD));
@@ -159,10 +166,13 @@ public class CBMicroblockModContent {
         r.register(new BlockMicroMaterial(Blocks.JUNGLE_LEAVES));
         r.register(new BlockMicroMaterial(Blocks.ACACIA_LEAVES));
         r.register(new BlockMicroMaterial(Blocks.DARK_OAK_LEAVES));
+        r.register(new BlockMicroMaterial(Blocks.AZALEA_LEAVES));
+        r.register(new BlockMicroMaterial(Blocks.FLOWERING_AZALEA_LEAVES));
         r.register(new BlockMicroMaterial(Blocks.SPONGE));
         r.register(new BlockMicroMaterial(Blocks.WET_SPONGE));
         r.register(new BlockMicroMaterial(Blocks.GLASS));
         r.register(new BlockMicroMaterial(Blocks.LAPIS_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_LAPIS_ORE));
         r.register(new BlockMicroMaterial(Blocks.LAPIS_BLOCK));
         r.register(new BlockMicroMaterial(Blocks.SANDSTONE));
         r.register(new BlockMicroMaterial(Blocks.CHISELED_SANDSTONE));
@@ -191,15 +201,20 @@ public class CBMicroblockModContent {
         r.register(new BlockMicroMaterial(Blocks.MOSSY_COBBLESTONE));
         r.register(new BlockMicroMaterial(Blocks.OBSIDIAN));
         r.register(new BlockMicroMaterial(Blocks.DIAMOND_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_DIAMOND_ORE));
         r.register(new BlockMicroMaterial(Blocks.DIAMOND_BLOCK));
         r.register(new BlockMicroMaterial(Blocks.CRAFTING_TABLE)); //TODO Actually function?
         r.register(new BlockMicroMaterial(Blocks.REDSTONE_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_REDSTONE_ORE));
         r.register(new BlockMicroMaterial(Blocks.ICE));
         r.register(new BlockMicroMaterial(Blocks.SNOW_BLOCK));
         r.register(new BlockMicroMaterial(Blocks.CLAY));
         r.register(new BlockMicroMaterial(Blocks.PUMPKIN));
         r.register(new BlockMicroMaterial(Blocks.NETHERRACK));
         r.register(new BlockMicroMaterial(Blocks.SOUL_SAND));
+        r.register(new BlockMicroMaterial(Blocks.SOUL_SOIL));
+        r.register(new BlockMicroMaterial(Blocks.BASALT));
+        r.register(new BlockMicroMaterial(Blocks.POLISHED_BASALT));
         r.register(new BlockMicroMaterial(Blocks.GLOWSTONE));
         r.register(new BlockMicroMaterial(Blocks.CARVED_PUMPKIN));
         r.register(new BlockMicroMaterial(Blocks.JACK_O_LANTERN));
@@ -230,7 +245,9 @@ public class CBMicroblockModContent {
         r.register(new BlockMicroMaterial(Blocks.MYCELIUM));
         r.register(new BlockMicroMaterial(Blocks.NETHER_BRICKS));
         r.register(new BlockMicroMaterial(Blocks.END_STONE));
+        r.register(new BlockMicroMaterial(Blocks.REDSTONE_LAMP.defaultBlockState().setValue(RedstoneLampBlock.LIT, true)));
         r.register(new BlockMicroMaterial(Blocks.EMERALD_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_EMERALD_ORE));
         r.register(new BlockMicroMaterial(Blocks.EMERALD_BLOCK));
         r.register(new BlockMicroMaterial(Blocks.REDSTONE_BLOCK));
         r.register(new BlockMicroMaterial(Blocks.NETHER_QUARTZ_ORE));
@@ -270,7 +287,9 @@ public class CBMicroblockModContent {
         r.register(new BlockMicroMaterial(Blocks.SMOOTH_QUARTZ));
         r.register(new BlockMicroMaterial(Blocks.SMOOTH_RED_SANDSTONE));
         r.register(new BlockMicroMaterial(Blocks.PURPUR_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.PURPUR_PILLAR));
         r.register(new BlockMicroMaterial(Blocks.END_STONE_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.DIRT_PATH));
         r.register(new BlockMicroMaterial(Blocks.MAGMA_BLOCK)); //TODO Burn?
         r.register(new BlockMicroMaterial(Blocks.NETHER_WART_BLOCK));
         r.register(new BlockMicroMaterial(Blocks.RED_NETHER_BRICKS));
@@ -335,6 +354,62 @@ public class CBMicroblockModContent {
         r.register(new BlockMicroMaterial(Blocks.FIRE_CORAL_BLOCK)); //TODO Dies out of water
         r.register(new BlockMicroMaterial(Blocks.HORN_CORAL_BLOCK)); //TODO Dies out of water
         r.register(new BlockMicroMaterial(Blocks.BLUE_ICE)); //TODO speed
+        r.register(new BlockMicroMaterial(Blocks.WARPED_NYLIUM));
+        r.register(new BlockMicroMaterial(Blocks.WARPED_WART_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.CRIMSON_NYLIUM));
+        r.register(new BlockMicroMaterial(Blocks.CRIMSON_PLANKS));
+        r.register(new BlockMicroMaterial(Blocks.WARPED_PLANKS));
+        r.register(new BlockMicroMaterial(Blocks.HONEY_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.HONEYCOMB_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.NETHERITE_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.ANCIENT_DEBRIS));
+        r.register(new BlockMicroMaterial(Blocks.CRYING_OBSIDIAN));
+        r.register(new BlockMicroMaterial(Blocks.LODESTONE));
+        r.register(new BlockMicroMaterial(Blocks.BLACKSTONE));
+        r.register(new BlockMicroMaterial(Blocks.POLISHED_BLACKSTONE));
+        r.register(new BlockMicroMaterial(Blocks.POLISHED_BLACKSTONE_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.CRACKED_POLISHED_BLACKSTONE_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.CHISELED_POLISHED_BLACKSTONE));
+        r.register(new BlockMicroMaterial(Blocks.GILDED_BLACKSTONE));
+        r.register(new BlockMicroMaterial(Blocks.CHISELED_NETHER_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.CRACKED_NETHER_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.QUARTZ_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.AMETHYST_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.TUFF));
+        r.register(new BlockMicroMaterial(Blocks.CALCITE));
+        r.register(new BlockMicroMaterial(Blocks.TINTED_GLASS));
+        r.register(new BlockMicroMaterial(Blocks.OXIDIZED_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WEATHERED_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.EXPOSED_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.COPPER_BLOCK)); //TODO Oxidization (normal -> exposed -> weathered -> oxidized)
+        r.register(new BlockMicroMaterial(Blocks.COPPER_ORE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_COPPER_ORE));
+        r.register(new BlockMicroMaterial(Blocks.OXIDIZED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WEATHERED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.EXPOSED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.CUT_COPPER)); //TODO Oxidization (normal -> exposed -> weathered -> oxidized)
+        r.register(new BlockMicroMaterial(Blocks.WAXED_COPPER_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_WEATHERED_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_EXPOSED_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_OXIDIZED_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_OXIDIZED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_WEATHERED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_EXPOSED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.WAXED_CUT_COPPER));
+        r.register(new BlockMicroMaterial(Blocks.DRIPSTONE_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.ROOTED_DIRT));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE));
+        r.register(new BlockMicroMaterial(Blocks.COBBLED_DEEPSLATE));
+        r.register(new BlockMicroMaterial(Blocks.POLISHED_DEEPSLATE));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_TILES));
+        r.register(new BlockMicroMaterial(Blocks.DEEPSLATE_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.CHISELED_DEEPSLATE));
+        r.register(new BlockMicroMaterial(Blocks.CRACKED_DEEPSLATE_BRICKS));
+        r.register(new BlockMicroMaterial(Blocks.CRACKED_DEEPSLATE_TILES));
+        r.register(new BlockMicroMaterial(Blocks.SMOOTH_BASALT));
+        r.register(new BlockMicroMaterial(Blocks.RAW_IRON_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.RAW_COPPER_BLOCK));
+        r.register(new BlockMicroMaterial(Blocks.RAW_GOLD_BLOCK));
     }
 
     private static void processIMC(InterModProcessEvent event) {

--- a/src/main/java/codechicken/microblock/part/MicroblockPlacement.java
+++ b/src/main/java/codechicken/microblock/part/MicroblockPlacement.java
@@ -5,10 +5,7 @@ import codechicken.lib.vec.Vector3;
 import codechicken.microblock.api.MicroMaterial;
 import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.block.TileMultipart;
-import codechicken.multipart.util.ControlKeyModifier;
-import codechicken.multipart.util.MultipartHelper;
-import codechicken.multipart.util.OffsetUseOnContext;
-import codechicken.multipart.util.PartRayTraceResult;
+import codechicken.multipart.util.*;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -152,7 +149,7 @@ public class MicroblockPlacement {
     @Nullable
     public ExecutablePlacement externalPlacement(MicroblockPart part) {
         BlockPos pos = this.pos.relative(Direction.from3DDataValue(side));
-        if (TileMultipart.canPlacePart(new OffsetUseOnContext(new UseOnContext(player, hand, hit)), part)) {
+        if (TileMultipart.canPlacePart(new MultipartPlaceContext(player, hand, hit).applyOffset(), part)) {
             return new ExecutablePlacement.AdditionPlacement(pos, part);
         }
         return null;

--- a/src/main/java/codechicken/multipart/api/PartConverter.java
+++ b/src/main/java/codechicken/multipart/api/PartConverter.java
@@ -2,6 +2,7 @@ package codechicken.multipart.api;
 
 import codechicken.multipart.CBMultipart;
 import codechicken.multipart.api.part.MultiPart;
+import codechicken.multipart.util.MultipartPlaceContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
@@ -46,10 +47,15 @@ public abstract class PartConverter extends ForgeRegistryEntry<PartConverter> {
     /**
      * Convert an {@link ItemStack} about to be placed into a {@link MultiPart} instance.
      *
-     * @param context The {@link UseOnContext} for the placement.
+     * @param context The {@link MultipartPlaceContext} for the placement.
      * @return A {@link ConversionResult}, providing the {@link MultiPart} instance if conversion
      * was successful.
      */
+    public ConversionResult<MultiPart> convert(MultipartPlaceContext context) {
+        return convert((UseOnContext) context);
+    }
+
+    @Deprecated(since = "1.18.2", forRemoval = true) // Use convert(MultipartPlaceContext)
     public ConversionResult<MultiPart> convert(UseOnContext context) {
         return emptyResult();
     }

--- a/src/main/java/codechicken/multipart/api/RedstoneInteractions.java
+++ b/src/main/java/codechicken/multipart/api/RedstoneInteractions.java
@@ -126,7 +126,7 @@ public class RedstoneInteractions {
         BlockState state = world.getBlockState(pos);
         Block block = state.getBlock();
         if (block instanceof RedstoneConnectorBlock bl) {
-            bl.getConnectionMask(world, pos, side);
+            return bl.getConnectionMask(world, pos, side);
         }
         return vanillaConnectionMask(world, pos, state, side, power);
     }

--- a/src/main/java/codechicken/multipart/api/RedstoneInteractions.java
+++ b/src/main/java/codechicken/multipart/api/RedstoneInteractions.java
@@ -12,10 +12,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.RedStoneWireBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.Set;
@@ -31,17 +28,6 @@ public class RedstoneInteractions {
      * Hardcoded vanilla overrides for Block.canConnectRedstone {@link RedstoneConnectorBlock}
      */
     private static final Set<Block> FULL_VANILLA_BLOCKS = ImmutableSet.<Block>builder()
-            .add(Blocks.REDSTONE_TORCH)
-            .add(Blocks.REDSTONE_WALL_TORCH)
-            .add(Blocks.LEVER)
-            .add(Blocks.STONE_BUTTON)
-            .add(Blocks.BIRCH_BUTTON)
-            .add(Blocks.ACACIA_BUTTON)
-            .add(Blocks.DARK_OAK_BUTTON)
-            .add(Blocks.JUNGLE_BUTTON)
-            .add(Blocks.OAK_BUTTON)
-            .add(Blocks.SPRUCE_BUTTON)
-            .add(Blocks.REDSTONE_BLOCK)
             .add(Blocks.REDSTONE_LAMP)
             .build();
 
@@ -141,13 +127,24 @@ public class RedstoneInteractions {
         }
 
         /*
-         * so that these can be conducted to from face parts on the other side of the block.
-         * Due to vanilla's inadequecy with redstone/logic on walls
+         * Manual overrides for FaceRedstonePart-like blocks, which can connect:
+         *  - on the 4 edges about the affixed face
+         *  - through the center on or opposite the affixed face
          */
-        if (block == Blocks.REDSTONE_WIRE || block == Blocks.COMPARATOR) {
+
+        // Dust
+        if (block == Blocks.REDSTONE_WIRE) {
+            if (side == 1) return 0;
             return power ? 0x1F : 4;
         }
 
+        // Comparator
+        if (block == Blocks.COMPARATOR) {
+            if (side == 0 || side == 1) return 0;
+            return power ? 0x1F : 4;
+        }
+
+        // Repeaters
         if (block == Blocks.REPEATER) { //stupid minecraft hardcodes
             int fside = state.getValue(HorizontalDirectionalBlock.FACING).ordinal();
             if ((side & 6) == (fside & 6)) {
@@ -155,6 +152,45 @@ public class RedstoneInteractions {
             }
             return 0;
         }
+
+        // Standing torches
+        if (block == Blocks.REDSTONE_TORCH) {
+            if (power) return 0x1F;
+
+            if (side == 0 || side == 1) { // Top or bottom face
+                return 0x10;
+            }
+            // Edge touching side 0
+            return 4;
+        }
+
+        // Wall torches
+        if (block == Blocks.REDSTONE_WALL_TORCH) {
+            if (power) return 0x1F;
+
+            int fside = state.getValue(RedstoneWallTorchBlock.FACING).getOpposite().ordinal();
+            if ((side & 6) == (fside & 6)) {
+                return 0x10;
+            }
+
+            // Edge between attached face and queried face
+            return 1 << Rotation.rotationTo(side & 6, fside);
+        }
+
+        // Buttons and levers
+        if (block instanceof ButtonBlock || block instanceof LeverBlock) {
+            if (power) return 0x1F;
+
+            int fside = FaceAttachedHorizontalDirectionalBlock.getConnectedDirection(state).getOpposite().ordinal();
+            if ((side & 6) == (fside & 6)) {
+                return 0x10;
+            }
+
+            // Edge between attached face and queried face
+            return 1 << Rotation.rotationTo(side & 6, fside);
+        }
+
+        // For all other blocks, rely on canConnectRedstone logic
         if (power || block.canConnectRedstone(state, world, pos, Direction.from3DDataValue(side))) {
             return 0x1F;
         }

--- a/src/main/java/codechicken/multipart/api/RedstoneInteractions.java
+++ b/src/main/java/codechicken/multipart/api/RedstoneInteractions.java
@@ -140,10 +140,6 @@ public class RedstoneInteractions {
             return 0x1F;
         }
 
-        if (side == 0) { //vanilla doesn't handle side 0
-            return power ? 0x1F : 0;
-        }
-
         /*
          * so that these can be conducted to from face parts on the other side of the block.
          * Due to vanilla's inadequecy with redstone/logic on walls

--- a/src/main/java/codechicken/multipart/handler/PlacementConversionHandler.java
+++ b/src/main/java/codechicken/multipart/handler/PlacementConversionHandler.java
@@ -1,13 +1,11 @@
 package codechicken.multipart.handler;
 
 import codechicken.lib.raytracer.RayTracer;
-import codechicken.lib.vec.Vector3;
-import codechicken.multipart.api.ItemMultipart;
 import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.block.TileMultipart;
 import codechicken.multipart.init.MultiPartRegistries;
 import codechicken.multipart.util.MultipartHelper;
-import codechicken.multipart.util.OffsetUseOnContext;
+import codechicken.multipart.util.MultipartPlaceContext;
 import net.covers1624.quack.util.CrashLock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundSource;
@@ -15,7 +13,6 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.phys.BlockHitResult;
@@ -55,20 +52,16 @@ public class PlacementConversionHandler {
         if (hit.getType() == HitResult.Type.MISS) {
             return false;
         }
-        double hitDepth = ItemMultipart.getHitDepth(
-                new Vector3(hit.getLocation()).subtract(hit.getBlockPos()),
-                hit.getDirection().ordinal()
-        );
-        UseOnContext ctx = new UseOnContext(player, hand, hit);
 
-        if (hitDepth < 1 && place(player, hand, ctx)) {
+        MultipartPlaceContext ctx = new MultipartPlaceContext(player, hand, hit);
+
+        if (ctx.getHitDepth() < 1 && place(player, hand, ctx)) {
             return true;
         }
-
-        return place(player, hand, new OffsetUseOnContext(ctx));
+        return place(player, hand, ctx.applyOffset());
     }
 
-    private static boolean place(Player player, InteractionHand hand, UseOnContext ctx) {
+    private static boolean place(Player player, InteractionHand hand, MultipartPlaceContext ctx) {
         Level world = ctx.getLevel();
         BlockPos pos = ctx.getClickedPos();
 

--- a/src/main/java/codechicken/multipart/init/MultiPartRegistries.java
+++ b/src/main/java/codechicken/multipart/init/MultiPartRegistries.java
@@ -6,11 +6,11 @@ import codechicken.multipart.api.MultipartType;
 import codechicken.multipart.api.PartConverter;
 import codechicken.multipart.api.PartConverter.ConversionResult;
 import codechicken.multipart.api.part.MultiPart;
+import codechicken.multipart.util.MultipartPlaceContext;
 import net.covers1624.quack.util.CrashLock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -156,7 +156,7 @@ public class MultiPartRegistries {
     }
 
     @Nullable
-    public static MultiPart convertItem(UseOnContext context) {
+    public static MultiPart convertItem(MultipartPlaceContext context) {
         for (PartConverter conv : PART_CONVERTERS.getValues()) {
             ConversionResult<MultiPart> result = conv.convert(context);
             if (result.success()) {

--- a/src/main/java/codechicken/multipart/minecraft/ButtonPart.java
+++ b/src/main/java/codechicken/multipart/minecraft/ButtonPart.java
@@ -1,8 +1,10 @@
 package codechicken.multipart.minecraft;
 
 import codechicken.multipart.api.MultipartType;
+import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.api.part.redstone.FaceRedstonePart;
 import codechicken.multipart.util.PartRayTraceResult;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -10,11 +12,15 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Arrow;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ButtonBlock;
 import net.minecraft.world.level.block.FaceAttachedHorizontalDirectionalBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.AttachFace;
 import net.minecraft.world.phys.shapes.CollisionContext;
+import org.jetbrains.annotations.Nullable;
 
 public class ButtonPart extends McSidedStatePart implements FaceRedstonePart {
 
@@ -49,6 +55,24 @@ public class ButtonPart extends McSidedStatePart implements FaceRedstonePart {
     @Override
     public Direction getSide() {
         return FaceAttachedHorizontalDirectionalBlock.getConnectedDirection(state).getOpposite();
+    }
+
+    @Override
+    public @Nullable MultiPart setStateOnPlacement(BlockPlaceContext context) {
+        Direction face = context.getClickedFace();
+
+        BlockState state = switch (face) {
+            case DOWN -> defaultBlockState().setValue(ButtonBlock.FACE, AttachFace.CEILING).setValue(ButtonBlock.FACING, context.getHorizontalDirection());
+            case UP -> defaultBlockState().setValue(ButtonBlock.FACE, AttachFace.FLOOR).setValue(ButtonBlock.FACING, context.getHorizontalDirection());
+            default -> defaultBlockState().setValue(ButtonBlock.FACE, AttachFace.WALL).setValue(ButtonBlock.FACING, face);
+        };
+
+        if (state.canSurvive(context.getLevel(), context.getClickedPos())) {
+            this.state = state;
+            return this;
+        }
+
+        return null;
     }
 
     public int delay() {

--- a/src/main/java/codechicken/multipart/minecraft/LeverPart.java
+++ b/src/main/java/codechicken/multipart/minecraft/LeverPart.java
@@ -2,6 +2,7 @@ package codechicken.multipart.minecraft;
 
 import codechicken.lib.data.MCDataInput;
 import codechicken.multipart.api.MultipartType;
+import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.api.part.redstone.FaceRedstonePart;
 import codechicken.multipart.util.PartRayTraceResult;
 import net.minecraft.core.Direction;
@@ -11,10 +12,13 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FaceAttachedHorizontalDirectionalBlock;
 import net.minecraft.world.level.block.LeverBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.AttachFace;
+import org.jetbrains.annotations.Nullable;
 
 public class LeverPart extends McSidedStatePart implements FaceRedstonePart {
 
@@ -47,6 +51,24 @@ public class LeverPart extends McSidedStatePart implements FaceRedstonePart {
     @Override
     public Direction getSide() {
         return FaceAttachedHorizontalDirectionalBlock.getConnectedDirection(state).getOpposite();
+    }
+
+    @Override
+    public @Nullable MultiPart setStateOnPlacement(BlockPlaceContext context) {
+        Direction face = context.getClickedFace();
+
+        BlockState state = switch (face) {
+            case DOWN -> defaultBlockState().setValue(LeverBlock.FACE, AttachFace.CEILING).setValue(LeverBlock.FACING, context.getHorizontalDirection());
+            case UP -> defaultBlockState().setValue(LeverBlock.FACE, AttachFace.FLOOR).setValue(LeverBlock.FACING, context.getHorizontalDirection());
+            default -> defaultBlockState().setValue(LeverBlock.FACE, AttachFace.WALL).setValue(LeverBlock.FACING, face);
+        };
+
+        if (state.canSurvive(context.getLevel(), context.getClickedPos())) {
+            this.state = state;
+            return this;
+        }
+
+        return null;
     }
 
     @Override

--- a/src/main/java/codechicken/multipart/minecraft/ModContent.java
+++ b/src/main/java/codechicken/multipart/minecraft/ModContent.java
@@ -5,11 +5,10 @@ import codechicken.multipart.api.MultipartType;
 import codechicken.multipart.api.PartConverter;
 import codechicken.multipart.api.SimpleMultipartType;
 import codechicken.multipart.api.part.MultiPart;
+import codechicken.multipart.util.MultipartPlaceContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -145,11 +144,11 @@ public class ModContent {
         }
 
         @Override
-        public ConversionResult<MultiPart> convert(UseOnContext context) {
+        public ConversionResult<MultiPart> convert(MultipartPlaceContext context) {
             if (context.getItemInHand().getItem() != item) {
                 return emptyResult();
             }
-            MultiPart result = factory.get().setStateOnPlacement(new BlockPlaceContext(context));
+            MultiPart result = factory.get().setStateOnPlacement(context);
             if (result != null) {
                 return ConversionResult.success(result);
             }

--- a/src/main/java/codechicken/multipart/util/MultipartPlaceContext.java
+++ b/src/main/java/codechicken/multipart/util/MultipartPlaceContext.java
@@ -1,0 +1,90 @@
+package codechicken.multipart.util;
+
+import codechicken.lib.vec.Rotation;
+import codechicken.lib.vec.Vector3;
+import codechicken.multipart.api.part.MultiPart;
+import codechicken.multipart.block.TileMultipart;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Contract;
+
+import java.util.Objects;
+
+public class MultipartPlaceContext extends BlockPlaceContext {
+
+    private final double hitDepth;
+    private final BlockPos offsetPos;
+
+    private boolean isOffset = false;
+
+    public MultipartPlaceContext(UseOnContext context) {
+        this(Objects.requireNonNull(context.getPlayer()), context.getHand(), context.getHitResult());
+    }
+
+    public MultipartPlaceContext(Player player, InteractionHand hand, BlockHitResult hit) {
+        super(player, hand, player.getItemInHand(hand), hit);
+
+        this.hitDepth = calcHitDepth(hit.getLocation(), hit.getBlockPos(), hit.getDirection());
+        this.offsetPos = hit.getBlockPos().relative(hit.getDirection());
+    }
+
+    /**
+     * Puts this placement into offset mode
+     *
+     * @return this
+     */
+    @Contract("-> this")
+    public MultipartPlaceContext applyOffset() {
+        isOffset = true;
+        return this;
+    }
+
+    /**
+     * Distance from the clicked face to that same face of the enclosing block space.
+     */
+    public double getHitDepth() {
+        return hitDepth;
+    }
+
+    /**
+     * False when placement is being run inside the clicked block, true when it is offset by one block.
+     */
+    public boolean isOffset() {
+        return isOffset;
+    }
+
+    /**
+     * Checks if part can be added to the world. Useful for cases where your part can optionally be altered
+     * if its initially calculated placement state cannot be placed.
+     * <p>
+     * For example, Lever parts are rectangular with a long and short side. Occlusion may allow placement in
+     * one orientation but not another. The initial placement state can be run through this method, and then
+     * rotated if placement is not possible.
+     * <p>
+     * Note that this method does not need to be used if conditional placement states are not required. This is
+     * explicitly re-checked once you return your candidate part.
+     *
+     * @param part The part to test
+     * @return True if placement is possible (either the space is empty, or occlusion allows placement)
+     */
+    public boolean canPlacePart(MultiPart part) {
+        return TileMultipart.canPlacePart(this, part);
+    }
+
+    @Override
+    public BlockPos getClickedPos() {
+        return isOffset ? offsetPos : getHitResult().getBlockPos();
+    }
+
+    private double calcHitDepth(Vec3 clickLocation, BlockPos clickPos, Direction face) {
+        Vector3 vHit = new Vector3(clickLocation).subtract(clickPos);
+        int side = face.ordinal();
+        return vHit.scalarProject(Rotation.axes[side]) + (side % 2 ^ 1);
+    }
+}

--- a/src/main/java/codechicken/multipart/util/OffsetUseOnContext.java
+++ b/src/main/java/codechicken/multipart/util/OffsetUseOnContext.java
@@ -6,6 +6,7 @@ import net.minecraft.world.item.context.UseOnContext;
 /**
  * Created by covers1624 on 1/1/21.
  */
+@Deprecated(since = "1.18.2", forRemoval = true) // Use MultipartPlaceContext
 public class OffsetUseOnContext extends UseOnContext {
 
     private final BlockPos pos;

--- a/src/main/java/codechicken/multipart/util/TickScheduler.java
+++ b/src/main/java/codechicken/multipart/util/TickScheduler.java
@@ -162,9 +162,10 @@ public class TickScheduler {
      * @param chunk The chunk.
      */
     public static void loadRandomTick(RandomTickPart part, LevelChunk chunk) {
-
-        WorldTickScheduler.ChunkScheduler chunkScheduler = WorldTickScheduler.getInstance(chunk);
-        chunkScheduler.loadRandomTick(part);
+        if (chunk.getLevel() instanceof ServerLevel) {
+            WorldTickScheduler.ChunkScheduler chunkScheduler = WorldTickScheduler.getInstance(chunk);
+            chunkScheduler.loadRandomTick(part);
+        }
     }
 
 }


### PR DESCRIPTION
* Fixed masks from RedstoneConnectorBlock not being used
* Remove legacy logic overriding canConnectRedstone for side 0. All faces are now correctly handled by it
* Add a client-side check in `TickScheduler#loadRandomTick`. This prevents client-side chuck corruption if world is loaded with any part that uses the TickScheduler (`RedstoneTorchPart` for example).
* Add custom placement state logic for both button and lever parts rather than rely on the block's logic. Takes care of more invalid placement edge cases
* Properly calculate Redstone connection masks for vanilla blocks rather than using `0x1F`. This stops connections from behaving differently if the block is vanilla or a converted part. Plus, this fixes comparators/dust from being connected from top face
* Register a bunch of new decorative 1.18 blocks as micro materials:
  * All Deepslate ores
  * Azalea leaves variants
  * Soul soil
  * Basalt variants
  * Lit redstone lamp
  * Purpur variants
  * Dirt path
  * Warped and crimson variants of Nylium, wart, planks, etc
  * Blackstone varients
  * Netherite, quartz, and nether brick variants
  * Honey, honeycomb
  * Lodestone
  * Blackstone variants
  * Crying obsidian
  * Copper block variants
  * Tuff
  * Calcite
  * Tinted glass 
* Add `MultipartPlaceContext` which improves placement context and also has native support for offset placement. It is also a subclass of `BlockPlaceContext` and is fully compatible with vanilla placement logic. All existing methods accepting a generic `UseOnContext` are kept and deprecated. Existing logic on those methods still work as before.