### PR TITLE
Fix brightness issues on static part rendering fallback

### DIFF
--- a/src/main/java/codechicken/multipart/api/part/render/PartRenderer.java
+++ b/src/main/java/codechicken/multipart/api/part/render/PartRenderer.java
@@ -62,6 +62,7 @@ public interface PartRenderer<T extends MultiPart> {
         CCRenderState ccrs = CCRenderState.instance();
         ccrs.hackyReallyDontComputeLighting = true;
         ccrs.reset();
+        ccrs.brightness = 0;
         BakedQuadVertexBuilder builder = new BakedQuadVertexBuilder();
         ccrs.bind(builder, DefaultVertexFormat.BLOCK);
         ccrs.lightMatrix.locate(part.level(), part.pos());


### PR DESCRIPTION
A non-zero brightness in ccrs will cause incorrect lighting to be baked. Force it to zero when baking part quads.